### PR TITLE
Updated Terminal to use KeyCode for ToggleHotkey and added support for multiple keys

### DIFF
--- a/CommandTerminal/Terminal.cs
+++ b/CommandTerminal/Terminal.cs
@@ -27,8 +27,7 @@ namespace CommandTerminal
         [SerializeField]
         float ToggleSpeed = 360;
 
-        [SerializeField] internal string ToggleHotkey      = "`";
-        [SerializeField] internal string ToggleFullHotkey  = "#`";
+        [SerializeField] internal KeyCode[] ToggleHotkeys = new KeyCode[] { KeyCode.BackQuote };
         [SerializeField] internal int BufferSize           = 512;
 
         [Header("Input")]
@@ -144,7 +143,10 @@ namespace CommandTerminal
 
             command_text = "";
             cached_command_text = command_text;
-            Assert.AreNotEqual(ToggleHotkey.ToLower(), "return", "Return is not a valid ToggleHotkey");
+            foreach (var toggleHotkey in ToggleHotkeys)
+            {
+                Assert.AreNotEqual(toggleHotkey, KeyCode.Return, "Return is not a valid ToggleHotkey");
+            }
 
             SetupWindow();
             SetupInput();
@@ -246,10 +248,18 @@ namespace CommandTerminal
                 move_cursor = true;
             } else if (Event.current.Equals(Event.KeyboardEvent("down"))) {
                 command_text = History.Next();
-            } else if (Event.current.Equals(Event.KeyboardEvent(ToggleHotkey))) {
-                ToggleState(TerminalState.OpenSmall);
-            } else if (Event.current.Equals(Event.KeyboardEvent(ToggleFullHotkey))) {
-                ToggleState(TerminalState.OpenFull);
+            } else if (Event.current.type == EventType.KeyDown) {
+                foreach (var toggleHotKey in ToggleHotkeys) {
+                    if (Event.current.keyCode == toggleHotKey) {
+                        if (Event.current.shift) {
+                            ToggleState(TerminalState.OpenFull);
+                        } else {
+                            ToggleState(TerminalState.OpenSmall);
+                        }
+
+                        break;
+                    }
+                }
             } else if (Event.current.Equals(Event.KeyboardEvent("tab"))) {
                 CompleteCommand();
                 move_cursor = true; // Wait till next draw call

--- a/CommandTerminal/TerminalKeyboardHandler.cs
+++ b/CommandTerminal/TerminalKeyboardHandler.cs
@@ -30,37 +30,42 @@ namespace CommandTerminal
         {
             // key presses won't be registered here while console is open and the input
             // field has focus, so they're handled in Terminal.OnGUI/DrawConsole
-            if (Input.GetKeyDown(terminal.ToggleHotkey))
+            var numOfToggleHotkeys = terminal.ToggleHotkeys.Length;
+            for (int i = 0; i < numOfToggleHotkeys; i++)
             {
-                bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
-
-                if (!terminal.enabled)
+                var toggleHotkey = terminal.ToggleHotkeys[i];
+                if (Input.GetKeyDown(toggleHotkey))
                 {
-                    terminal.enabled = true;
+                    bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
 
-                    if (shift)
+                    if (!terminal.enabled)
                     {
-                        terminal.SetState(TerminalState.OpenFull);
+                        terminal.enabled = true;
+
+                        if (shift)
+                        {
+                            terminal.SetState(TerminalState.OpenFull);
+                        }
+                        else
+                        {
+                            terminal.SetState(TerminalState.OpenSmall);
+                        }
+
+                        terminal.initial_open = true;
                     }
                     else
                     {
-                        terminal.SetState(TerminalState.OpenSmall);
-                    }
+                        // this is only entered when console is open and
+                        // the input field has lost focus
 
-                    terminal.initial_open = true;
-                }
-                else
-                {
-                    // this is only entered when console is open and
-                    // the input field has lost focus
-
-                    if (shift)
-                    {
-                        terminal.ToggleState(TerminalState.OpenFull);
-                    }
-                    else
-                    {
-                        terminal.SetState(TerminalState.Close);
+                        if (shift)
+                        {
+                            terminal.ToggleState(TerminalState.OpenFull);
+                        }
+                        else
+                        {
+                            terminal.SetState(TerminalState.Close);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
String value for input is pretty bad if you want to incorporate this with any custom key bindings system that uses KeyCodes.
Yeah, there's no such function that can do conversion KeyCode -> string and vice versa.


Also ability to customize full hotkey is removed. It was already constrained, and in theory non-customizable due to code in TerminalKeyboardHandler.