### PR TITLE
Initialize in Awake instead of Start, execution order -999

### DIFF
--- a/CommandTerminal/Terminal.cs
+++ b/CommandTerminal/Terminal.cs
@@ -134,7 +134,7 @@ namespace CommandTerminal
             }
         }
 
-        void Start() {
+        void Awake() {
             if (ConsoleFont == null) {
                 ConsoleFont = Font.CreateDynamicFontFromOSFont("Courier New", 16);
                 Debug.LogWarning("Command Console Warning: Please assign a font.");

--- a/CommandTerminal/Terminal.cs.meta
+++ b/CommandTerminal/Terminal.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -999
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
This aims to fix early `Debug.Log`s not appearing in console because they were logged before CommandTerminal got initialized.

I chose the execution order to be -999 because I saw in a new project that `UnityEngine.EventSystems.EventSystem` uses -1000 so I made it one after that just in case, I didn't actually test anything related to `EventSystem`.