### PR TITLE
Made terminal open/close input separate

### DIFF
--- a/CommandTerminal/Terminal.cs
+++ b/CommandTerminal/Terminal.cs
@@ -27,7 +27,7 @@ namespace CommandTerminal
         [SerializeField]
         float ToggleSpeed = 360;
 
-        [SerializeField] public KeyCode[] ToggleHotkeys = new KeyCode[] { KeyCode.BackQuote };
+        [SerializeField] public TerminalKeyboardInputProvider inputProvider;
         [SerializeField] internal int BufferSize           = 512;
 
         [Header("Input")]
@@ -124,6 +124,8 @@ namespace CommandTerminal
             }
 
             state = new_state;
+            // You can use this to disable player inputs while console is open, if not using the old input system.
+            inputProvider.SetTerminalOpen(state != TerminalState.Close);
         }
 
         public void ToggleState(TerminalState new_state) {
@@ -147,10 +149,6 @@ namespace CommandTerminal
 
             command_text = "";
             cached_command_text = command_text;
-            foreach (var toggleHotkey in ToggleHotkeys)
-            {
-                Assert.AreNotEqual(toggleHotkey, KeyCode.Return, "Return is not a valid ToggleHotkey");
-            }
 
             SetupWindow();
             SetupInput();
@@ -273,15 +271,13 @@ namespace CommandTerminal
                 move_cursor = true; // Wait till next draw call
             } else if (Event.current.type == EventType.KeyDown && Event.current.character != '\t') {
                 if (!Event.current.shift) last_input_was_tab = false;  // allow shift-tab to cycle completions backwards
-                foreach (var toggleHotKey in ToggleHotkeys) {
-                    if (Event.current.keyCode == toggleHotKey) {
-                        if (Event.current.shift) {
-                            ToggleState(TerminalState.OpenFull);
-                        } else {
-                            ToggleState(TerminalState.OpenSmall);
-                        }
 
-                        break;
+                if (inputProvider.GetButtonDown())
+                {
+                    if (Event.current.shift) {
+                        ToggleState(TerminalState.OpenFull);
+                    } else {
+                        ToggleState(TerminalState.OpenSmall);
                     }
                 }
             }

--- a/CommandTerminal/TerminalKeyboardHandler.cs
+++ b/CommandTerminal/TerminalKeyboardHandler.cs
@@ -30,42 +30,37 @@ namespace CommandTerminal
         {
             // key presses won't be registered here while console is open and the input
             // field has focus, so they're handled in Terminal.OnGUI/DrawConsole
-            var numOfToggleHotkeys = terminal.ToggleHotkeys.Length;
-            for (int i = 0; i < numOfToggleHotkeys; i++)
+            if (terminal.inputProvider.GetButtonDown())
             {
-                var toggleHotkey = terminal.ToggleHotkeys[i];
-                if (Input.GetKeyDown(toggleHotkey))
+                bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+
+                if (!terminal.enabled)
                 {
-                    bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+                    terminal.enabled = true;
 
-                    if (!terminal.enabled)
+                    if (shift)
                     {
-                        terminal.enabled = true;
-
-                        if (shift)
-                        {
-                            terminal.SetState(TerminalState.OpenFull);
-                        }
-                        else
-                        {
-                            terminal.SetState(TerminalState.OpenSmall);
-                        }
-
-                        terminal.initial_open = true;
+                        terminal.SetState(TerminalState.OpenFull);
                     }
                     else
                     {
-                        // this is only entered when console is open and
-                        // the input field has lost focus
+                        terminal.SetState(TerminalState.OpenSmall);
+                    }
 
-                        if (shift)
-                        {
-                            terminal.ToggleState(TerminalState.OpenFull);
-                        }
-                        else
-                        {
-                            terminal.SetState(TerminalState.Close);
-                        }
+                    terminal.initial_open = true;
+                }
+                else
+                {
+                    // this is only entered when console is open and
+                    // the input field has lost focus
+
+                    if (shift)
+                    {
+                        terminal.ToggleState(TerminalState.OpenFull);
+                    }
+                    else
+                    {
+                        terminal.SetState(TerminalState.Close);
                     }
                 }
             }

--- a/CommandTerminal/TerminalKeyboardInputProvider.cs
+++ b/CommandTerminal/TerminalKeyboardInputProvider.cs
@@ -1,0 +1,7 @@
+﻿using UnityEngine;
+
+public abstract class TerminalKeyboardInputProvider : MonoBehaviour
+{
+    public abstract bool GetButtonDown();
+    public abstract void SetTerminalOpen(bool open);
+}

--- a/CommandTerminal/TerminalKeyboardInputProvider.cs.meta
+++ b/CommandTerminal/TerminalKeyboardInputProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebcae7d56f26ee74abdb3ab3573cb0ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CommandTerminal/TerminalKeyboardInputProviderMock.cs
+++ b/CommandTerminal/TerminalKeyboardInputProviderMock.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+
+namespace CommandTerminal
+{
+    public class TerminalKeyboardInputProviderMock : TerminalKeyboardInputProvider
+    {
+        public override bool GetButtonDown() => Input.GetKeyDown(KeyCode.BackQuote);
+
+        public override void SetTerminalOpen(bool open) { }
+    }
+}

--- a/CommandTerminal/TerminalKeyboardInputProviderMock.cs.meta
+++ b/CommandTerminal/TerminalKeyboardInputProviderMock.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7c9a191f3fd0468980b4c15664469d5b
+timeCreated: 1744279344


### PR DESCRIPTION
This PR abstracts away open/close terminal input so that you can implement it with other systems than Unity's old(TM) input system. 